### PR TITLE
🐛 Fix default config directory permission to 0755

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func LoadSettings(setting Setting, automake bool) (Setting, error) {
 }
 
 func InitializeConfigFile(ConfigPath string) error {
-	if err := os.MkdirAll(filepath.Dir(ConfigPath), 0644); err != nil {
+	if err := os.MkdirAll(filepath.Dir(ConfigPath), 0755); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Creating config directory initially, config file isn't created because `permission denied` as below.

```bash
$ deepl-translate-cli
2022/03/12 18:12:28 open /home/USERNAME/.config/deepl-translate-cli/setting.json: permission denied
```

So I fixed it.

After fixed, config file was created correctly.

```bash
$ deepl-translate-cli
2022/03/12 18:25:06 Not exists such file. /home/USERNAME/.config/deepl-translate-cli/setting.json
        auto make it, please write it.
exit status 1
```

Note:

`~/.config/deepl-translate-cli` directory permission is always `0777` but `~/.config/deepl-translate-cli/setting.json` permission depends on user's `umask`.
